### PR TITLE
Fix import of collections.abc.Mapping

### DIFF
--- a/mybibtex/database.py
+++ b/mybibtex/database.py
@@ -21,7 +21,7 @@
 
 import re
 
-from collections import Mapping
+from collections.abc import Mapping
 from functools import total_ordering
 
 from pybtex.exceptions import PybtexError


### PR DESCRIPTION
Fix the import, otherwise this fails on Python 3.10
